### PR TITLE
Simplify Blockstack singleton

### DIFF
--- a/Blockstack/Classes/Blockstack.swift
+++ b/Blockstack/Classes/Blockstack.swift
@@ -9,24 +9,9 @@ import Foundation
 
 open class Blockstack {
     
-    private var instance: BlockstackInstance?
-    
-    private static var shared: Blockstack = {
-        let blockstack = Blockstack()
-        return blockstack
+    public static let shared: BlockstackInstance = {
+        return BlockstackInstance()
     }()
     
-    open class func sharedInstance() -> BlockstackInstance {
-        return shared.getInstance()
-    }
-    
-    private init() {
-        instance = BlockstackInstance()
-    }
-    
-    private func getInstance() -> BlockstackInstance {
-        return instance!
-    }
 }
-
 

--- a/Example/Blockstack/ViewController.swift
+++ b/Example/Blockstack/ViewController.swift
@@ -29,7 +29,7 @@ class ViewController: UIViewController {
     }
 
     @objc func signin() {
-        Blockstack.sharedInstance().signIn(redirectURI: "http://localhost:8080/redirect.html",
+        Blockstack.shared.signIn(redirectURI: "http://localhost:8080/redirect.html",
                                            appDomain: URL(string: "http://localhost:8080")!) { authResult in
             switch authResult {
                 case .success(let userData):
@@ -49,7 +49,7 @@ class ViewController: UIViewController {
         print(userData.profile?.name as Any)
         
         // Read user profile data
-        let retrievedUserData = Blockstack.sharedInstance().loadUserData()
+        let retrievedUserData = Blockstack.shared.loadUserData()
         print(retrievedUserData?.profile?.name as Any)
         
         DispatchQueue.main.async {
@@ -61,14 +61,14 @@ class ViewController: UIViewController {
         // Store data on Gaia
         let content: Dictionary<String, String> = ["property":"value"]
         
-        Blockstack.sharedInstance().putFile(path: "test.json", content: content) { (publicURL, error) in
+        Blockstack.shared.putFile(path: "test.json", content: content) { (publicURL, error) in
             if (error != nil) {
                 print("put file error")
             } else {
                 print("put file success \(publicURL!)")
                 
                 // Read data from Gaia
-                Blockstack.sharedInstance().getFile(path: "test.json", completion: { (response, error) in
+                Blockstack.shared.getFile(path: "test.json", completion: { (response, error) in
                     if (error != nil) {
                         print("get file error")
                     } else {
@@ -87,7 +87,7 @@ class ViewController: UIViewController {
     }
     
     func checkIfSignedIn() {
-        if (Blockstack.sharedInstance().isSignedIn()) {
+        if (Blockstack.shared.isSignedIn()) {
             print("currently signed in")
         } else {
             print("not signed in")

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ import Blockstack
 In this example, your web app would be located at `http://localhost:8080`
 
 ```swift
-Blockstack.sharedInstance().signIn(redirectURI: "http://localhost:8080/redirect.html",
+Blockstack.shared.signIn(redirectURI: "http://localhost:8080/redirect.html",
                                    appDomain: URL(string: "http://localhost:8080")!) { authResult in
     switch authResult {
         case .success(let userData):
@@ -78,7 +78,7 @@ Blockstack.sharedInstance().signIn(redirectURI: "http://localhost:8080/redirect.
 
 
 ```swift
-if (Blockstack.sharedInstance().isSignedIn()) {
+if (Blockstack.shared.isSignedIn()) {
     print("currently signed in")
 } else {
     print("not signed in")
@@ -88,7 +88,7 @@ if (Blockstack.sharedInstance().isSignedIn()) {
 #### Sign out
 
 ```swift
-Blockstack.sharedInstance().signOut()
+Blockstack.shared.signOut()
 ```
 
 #### Retrieve user profile data
@@ -103,7 +103,7 @@ print(retrievedUserData?.profile?.name as Any)
 Store data as json on Gaia
 
 ```swift
-Blockstack.sharedInstance().putFile(path: "myFile.json", content: content) { (publicURL, error) in
+Blockstack.shared.putFile(path: "myFile.json", content: content) { (publicURL, error) in
     if (error != nil) {
         print("put file error")
     } else {
@@ -115,7 +115,7 @@ Blockstack.sharedInstance().putFile(path: "myFile.json", content: content) { (pu
 Read json data from Gaia
 
 ```swift
-Blockstack.sharedInstance().getFile(path: "myFile.json", completion: { (response, error) in
+Blockstack.shared.getFile(path: "myFile.json", completion: { (response, error) in
     if (error != nil) {
         print("get file error")
     } else {


### PR DESCRIPTION
using `shared` variable instead of `sharedInstance()` seems more Swifty and is a standard in Apple API e.g. [UIApplication.shared](https://developer.apple.com/documentation/uikit/uiapplication/1622975-shared)