### PR TITLE
Feedback from working with Afari

### DIFF
--- a/Blockstack+ObjC.swift
+++ b/Blockstack+ObjC.swift
@@ -8,6 +8,18 @@
 import Foundation
 
 extension Blockstack {
+    /**
+     Decrypts data encrypted with `encryptContent` with the given private key.
+     - parameter privateKey: The hex string of the ECDSA private key to use for decryption. If not provided, will use user's appPrivateKey.
+     - returns: DecryptedValue object containing Byte or String content.
+     */
+    @objc(decryptContent:privateKey:)
+    public func objc_decryptContent(content: String, privateKey: String? = nil) -> ObjCDecryptedValue? {
+        guard let decryptedValue = self.decryptContent(content: content, privateKey: privateKey) else {
+            return nil
+        }
+        return ObjCDecryptedValue(decryptedValue)
+    }
     
     /**
      Retrieves the user data object. The user's profile is stored in the key `profile`.

--- a/Blockstack/Classes/Blockstack.swift
+++ b/Blockstack/Classes/Blockstack.swift
@@ -110,16 +110,13 @@ public enum BlockstackConstants {
     }
     
     /**
-     Clear the keychain and all settings for this device.
+     Prompt web flow to clear the keychain and all settings for this device.
      WARNING: This will reset the keychain for all apps using Blockstack sign in. Apps that are already signed in will not be affected, but the user will have to reenter their 12 word seed to sign in to any new apps.
-     - parameter redirectURI: A custom scheme registered in the app Info.plist, i.e. "myBlockstackApp"
-     - parameter completion: Callback indicating success or failure.
      */
-    @objc public func promptClearDeviceKeychain(redirectUri: String, completion: @escaping (Error?) -> ()) {
+    @objc public func promptClearDeviceKeychain() {
         // TODO: Use ASWebAuthenticationSession for iOS 12
-        self.sfAuthSession = SFAuthenticationSession(url: URL(string: "\(BlockstackConstants.BrowserWebClearAuthEndpoint)?redirect_uri=\(redirectUri)")!, callbackURLScheme: nil) { _, error in
+        self.sfAuthSession = SFAuthenticationSession(url: URL(string: "\(BlockstackConstants.BrowserWebClearAuthEndpoint)")!, callbackURLScheme: nil) { _, error in
             self.sfAuthSession = nil
-            completion(error)
         }
         self.sfAuthSession?.start()
     }

--- a/Blockstack/Classes/Blockstack.swift
+++ b/Blockstack/Classes/Blockstack.swift
@@ -20,7 +20,6 @@ public enum BlockstackConstants {
     public static let AuthProtocolVersion = "1.1.0"
     public static let DefaultGaiaHubURL = "https://hub.blockstack.org"
     public static let ProfileUserDefaultLabel = "BLOCKSTACK_PROFILE_LABEL"
-    public static let TransitPrivateKeyUserDefaultLabel = "BLOCKSTACK_TRANSIT_PRIVATE_KEY"
     public static let GaiaHubConfigUserDefaultLabel = "GAIA_HUB_CONFIG"
     public static let AppOriginUserDefaultLabel = "BLOCKSTACK_APP_ORIGIN"
 }
@@ -48,7 +47,7 @@ public enum BlockstackConstants {
                      completion: @escaping (AuthResult) -> ()) {
         print("signing in")
         
-        guard let transitKey = Keys.generateTransitKey() else {
+        guard let transitKey = Keys.makeECPrivateKey() else {
             print("Failed to generate transit key")
             return
         }
@@ -106,7 +105,6 @@ public enum BlockstackConstants {
     }
     
     @objc public func signOut() {
-        Keys.clearTransitKey()
         ProfileHelper.clearProfile()
         Gaia.clearSession()
     }

--- a/Blockstack/Classes/Blockstack.swift
+++ b/Blockstack/Classes/Blockstack.swift
@@ -257,7 +257,58 @@ public enum BlockstackConstants {
                 completion: completion)
         }
     }
-
+    
+    /**
+     Encrypts the data provided with the app public key.
+     - parameter bytes: Bytes (Array<UInt8>) data to encrypt.
+     - parameter publicKey: The hex string of the ECDSA public key to use for encryption. If not provided, will use a public key derived from user's appPrivateKey.
+     - returns: Stringified JSON ciphertext object
+     */
+    @objc public func encryptContent(bytes: Bytes, publicKey: String? = nil) -> String? {
+        let key: String?
+        if publicKey == nil, let privateKey = Blockstack.shared.loadUserData()?.privateKey {
+            key = Keys.getPublicKeyFromPrivate(privateKey)
+        } else {
+            key = publicKey
+        }
+        guard let recipientKey = key else {
+            return nil
+        }
+        return Encryption.encryptECIES(content: bytes, recipientPublicKey: recipientKey, isString: false)
+    }
+    
+    /**
+     Encrypts the data provided with the app public key.
+     - parameter text: String data to encrypt
+     - parameter publicKey: The hex string of the ECDSA public key to use for encryption. If not provided, will use a public key derived from user's appPrivateKey.
+     - returns: Stringified JSON ciphertext object
+     */
+    @objc public func encryptContent(text: String, publicKey: String? = nil) -> String? {
+        let key: String?
+        if publicKey == nil, let privateKey = Blockstack.shared.loadUserData()?.privateKey {
+            key = Keys.getPublicKeyFromPrivate(privateKey)
+        } else {
+            key = publicKey
+        }
+        guard let recipientKey = key else {
+            return nil
+        }
+        return Encryption.encryptECIES(content: text, recipientPublicKey: recipientKey)
+    }
+    
+    /**
+     Decrypts data encrypted with `encryptContent` with the transit private key.
+     - parameter content: Encrypted, JSON stringified content.
+     - parameter privateKey: The hex string of the ECDSA private key to use for decryption. If not provided, will use user's appPrivateKey.
+     - returns: DecryptedValue object containing Byte or String content.
+     */
+    public func decryptContent(content: String, privateKey: String? = nil) -> DecryptedValue? {
+        guard let key = privateKey ?? Blockstack.shared.loadUserData()?.privateKey else {
+            return nil
+        }
+        return Encryption.decryptECIES(cipherObjectJSONString: content, privateKey: key)
+    }
+    
     // MARK: - Private
     
     // TODO: Return errors in completion handler

--- a/Blockstack/Classes/DataTypes.swift
+++ b/Blockstack/Classes/DataTypes.swift
@@ -46,11 +46,23 @@ public struct Profile: Codable {
     public let name: String?
     public let description: String?
     public let apps: [String: String]?
+    public let image: [Content]?
     
     enum CodingKeys: String, CodingKey {
         case type = "@type"
         case context = "@context"
-        case name, description, apps
+        case name, description, apps, image
+    }
+}
+
+public struct Content: Codable {
+    public let type: String?
+    public let name: String?
+    public let contentUrl: String?
+    
+    enum CodingKeys: String, CodingKey {
+        case type = "@type"
+        case name, contentUrl
     }
 }
 

--- a/Blockstack/Classes/Encryption.swift
+++ b/Blockstack/Classes/Encryption.swift
@@ -8,7 +8,7 @@
 import Foundation
 import CryptoSwift
 
-public class Encryption {
+class Encryption {
 
     static func decryptPrivateKey(privateKey: String, hexedEncrypted: String) -> String? {
         let encryptedData = Data(fromHexEncodedString: hexedEncrypted)
@@ -17,7 +17,7 @@ public class Encryption {
         return encryptionJS.decryptECIES(privateKey: privateKey, cipherObjectJSONString: cipherObjectJSONString!)?.plainText
     }
     
-    public static func encryptECIES(recipientPublicKey: String, content: Bytes, isString: Bool) -> String? {
+    static func encryptECIES(content: Bytes, recipientPublicKey: String, isString: Bool) -> String? {
         guard let ephemeralSK = Keys.makeECPrivateKey(),
             let sharedSecret = Keys.deriveSharedSecret(ephemeralSecretKey: ephemeralSK, recipientPublicKey: recipientPublicKey) else {
             return nil
@@ -50,22 +50,23 @@ public class Encryption {
         return nil
     }
     
-    public static func encryptECIES(recipientPublicKey: String, content: String) -> String? {
-        return self.encryptECIES(recipientPublicKey: recipientPublicKey, content: Array(content.utf8), isString: true)
+    static func encryptECIES(content: String, recipientPublicKey: String) -> String? {
+        return self.encryptECIES(content: Array(content.utf8), recipientPublicKey: recipientPublicKey, isString: true)
     }
     
-    public static func decryptECIES(privateKey: String, cipherObjectJSONString: String) -> DecryptedValue? {
+    static func decryptECIES(cipherObjectJSONString: String, privateKey: String) -> DecryptedValue? {
         return EncryptionJS().decryptECIES(privateKey: privateKey, cipherObjectJSONString: cipherObjectJSONString)
     }
 }
 
 public struct DecryptedValue {
-    public var isString: Bool {
-        return self.plainText != nil
-    }
     public let plainText: String?
     public let bytes: Bytes?
     
+    public var isString: Bool {
+        return self.plainText != nil
+    }
+
     init(text: String) {
         self.plainText = text
         self.bytes = nil

--- a/Blockstack/Classes/GaiaHubSession.swift
+++ b/Blockstack/Classes/GaiaHubSession.swift
@@ -41,7 +41,7 @@ public class GaiaHubSession {
                             completion(nil, nil)
                             return
                         }
-                        let decryptedValue = Encryption.decryptECIES(privateKey: privateKey, cipherObjectJSONString: text)
+                        let decryptedValue = Encryption.decryptECIES(cipherObjectJSONString: text, privateKey: privateKey)
                         completion(decryptedValue, nil)
                     } else {
                         completion(text, nil)
@@ -107,9 +107,9 @@ public class GaiaHubSession {
         var cipherObjectJSON: String?
         switch content {
         case let .bytes(bytes):
-            cipherObjectJSON = Encryption.encryptECIES(recipientPublicKey: publicKey, content: bytes, isString: false)
+            cipherObjectJSON = Encryption.encryptECIES(content: bytes, recipientPublicKey: publicKey, isString: false)
         case let .text(text):
-            cipherObjectJSON = Encryption.encryptECIES(recipientPublicKey: publicKey, content: text)
+            cipherObjectJSON = Encryption.encryptECIES(content: text, recipientPublicKey: publicKey)
         }
         
         guard let cipher = cipherObjectJSON else {

--- a/Blockstack/Classes/Keys.swift
+++ b/Blockstack/Classes/Keys.swift
@@ -20,12 +20,12 @@ enum secp256k1Curve {
 open class Keys {
     
     /**
-     Generates a set of random bytes.
-     - parameter byteLength: Byte count of the resulting hex string.
+     Generates a string from a set of random bytes.
+     - parameter numberOfBytes: Byte count of the resulting hex string.
      - returns: Hex string cmoprised of random bytes of the given length.
     */
-    @objc open static func generateRandomBytes(byteLength: Int = 32) -> String? {
-        var randomData = Data(count: byteLength)
+    @objc open static func getEntropy(numberOfBytes: Int = 32) -> String? {
+        var randomData = Data(count: numberOfBytes)
         let count = randomData.count
         let result = randomData.withUnsafeMutableBytes {
             SecRandomCopyBytes(kSecRandomDefault, count, $0)
@@ -38,7 +38,6 @@ open class Keys {
         }
     }
 
-    
     /**
      Get the associated public key from a given private key on the secp256k1 elliptic curve.
      - parameter privateKey: The private key from which to derive the public key.
@@ -59,7 +58,7 @@ open class Keys {
         var d: _BigInt<UInt>?
         
         repeat {
-            let randomBytes = generateRandomBytes()
+            let randomBytes = self.getEntropy()
             d = _BigInt<UInt>(randomBytes!, radix: 16)
         } while (d!.isNegative
             || d!.isZero

--- a/Blockstack/Classes/Keys.swift
+++ b/Blockstack/Classes/Keys.swift
@@ -19,7 +19,36 @@ enum secp256k1Curve {
 
 open class Keys {
     
+    /**
+     Generates a set of random bytes.
+     - parameter byteLength: Byte count of the resulting hex string.
+     - returns: Hex string cmoprised of random bytes of the given length.
+    */
+    open static func generateRandomBytes(byteLength: Int = 32) -> String? {
+        var randomData = Data(count: byteLength)
+        let count = randomData.count
+        let result = randomData.withUnsafeMutableBytes {
+            SecRandomCopyBytes(kSecRandomDefault, count, $0)
+        }
+        if result == errSecSuccess {
+            return randomData.hexEncodedString()
+        } else {
+            print("Problem generating random bytes")
+            return nil
+        }
+    }
+
     
+    /**
+     Get the associated public key from a given private key on the secp256k1 elliptic curve.
+     - parameter privateKey: The private key from which to derive the public key.
+     - parameter compressed: Boolean indicating whether the returned public key should be compressed.
+     - returns: Complementing, optionally compressed public key for given private key.
+     */
+    open static func getPublicKeyFromPrivate(_ privateKey: String, compressed: Bool = false) -> String? {
+        return EllipticJS().getPublicKeyFromPrivate(privateKey, compressed: compressed)
+    }
+
     /**
      Generate an elliptic curve private key for secp256k1.
      */
@@ -39,24 +68,6 @@ open class Keys {
             || d?._compare(to: nBigInt!) == .greaterThan)
         
         return d?.toString(radix: 16, lowercase: true).paddingLeft(to: keyLength * 2, with: "0")
-    }
-    
-    open static func generateRandomBytes(bytes: Int = 32) -> String? {
-        var randomData = Data(count: bytes)
-        let count = randomData.count
-        let result = randomData.withUnsafeMutableBytes {
-            SecRandomCopyBytes(kSecRandomDefault, count, $0)
-        }
-        if result == errSecSuccess {
-            return randomData.hexEncodedString()
-        } else {
-            print("Problem generating random bytes")
-            return nil
-        }
-    }
-    
-    open static func getPublicKeyFromPrivate(_ privateKey: String, compressed: Bool = false) -> String? {
-        return EllipticJS().getPublicKeyFromPrivate(privateKey, compressed: compressed)
     }
     
     static func getAddressFromPublicKey(_ publicKey: String) -> String? {

--- a/Blockstack/Classes/Keys.swift
+++ b/Blockstack/Classes/Keys.swift
@@ -24,7 +24,7 @@ open class Keys {
      - parameter byteLength: Byte count of the resulting hex string.
      - returns: Hex string cmoprised of random bytes of the given length.
     */
-    open static func generateRandomBytes(byteLength: Int = 32) -> String? {
+    @objc open static func generateRandomBytes(byteLength: Int = 32) -> String? {
         var randomData = Data(count: byteLength)
         let count = randomData.count
         let result = randomData.withUnsafeMutableBytes {
@@ -45,15 +45,14 @@ open class Keys {
      - parameter compressed: Boolean indicating whether the returned public key should be compressed.
      - returns: Complementing, optionally compressed public key for given private key.
      */
-    open static func getPublicKeyFromPrivate(_ privateKey: String, compressed: Bool = false) -> String? {
+    @objc open static func getPublicKeyFromPrivate(_ privateKey: String, compressed: Bool = false) -> String? {
         return EllipticJS().getPublicKeyFromPrivate(privateKey, compressed: compressed)
     }
 
     /**
      Generate an elliptic curve private key for secp256k1.
      */
-    open static func makeECPrivateKey() -> String? {
-        
+    @objc open static func makeECPrivateKey() -> String? {
         let keyLength = 32
         let n = secp256k1Curve.n
         let nBigInt = _BigInt<UInt>(n, radix: 16)

--- a/Blockstack/Classes/Keys.swift
+++ b/Blockstack/Classes/Keys.swift
@@ -19,87 +19,20 @@ enum secp256k1Curve {
 
 open class Keys {
     
-    /**
-     Generate the transit private key
-     TODO - Use Keychain for secure key storage
-     */
-    static func generateTransitKey() -> String? {
-        let transitKey = makeECPrivateKey()
-        
-        storeKey(keyData: transitKey!, label: BlockstackConstants.TransitPrivateKeyUserDefaultLabel)
-        
-        return transitKey
-//        print("storing transit key")
-//        print(transitKey as Any)
-        
-//        let key = transitKey
-//        let tag = "org.test.keys.appKey".data(using: .utf8)!
-//        let addquery: [String: Any] = [kSecClass as String: kSecClassKey,
-//                                       kSecAttrApplicationTag as String: tag,
-//                                       kSecValueRef as String: key as Any]
-//        let status = SecItemAdd(addquery as CFDictionary, nil)
-//        guard status == errSecSuccess else {
-//            print("ERROR STORING KEY")
-//            print(status)
-//            return nil
-//        }
-    }
-    
-    static func retrieveTransitKey() -> String? {
-        return retrieveKey(label: BlockstackConstants.TransitPrivateKeyUserDefaultLabel)
-        
-//        let tag = "org.test.keys.appKey".data(using: .utf8)!
-//        let getquery: [String: Any] = [kSecClass as String: kSecClassKey,
-//                                       kSecAttrApplicationTag as String: tag,
-//                                       kSecAttrKeyType as String: kSecAttrKeyTypeEC,
-//                                       kSecReturnRef as String: true]
-//
-//        var item: CFTypeRef?
-//        let status = SecItemCopyMatching(getquery as CFDictionary, &item)
-//        guard status == errSecSuccess else {
-//            print("ERROR RETRIEVING KEY")
-//            return
-//        }
-//        let key = item as! SecKey
-//        print("printing retrieved key")
-//        print(key)
-    }
-    
-    static func clearTransitKey() {
-        return clearKeys(label: BlockstackConstants.TransitPrivateKeyUserDefaultLabel)
-    }
-    
-    static func storeKey(keyData: String, label: String) {
-        UserDefaults.standard.set(keyData, forKey: label)
-    }
-    
-    static func retrieveKey(label: String) -> String? {
-        return UserDefaults.standard.string(forKey: label)
-    }
-    
-    static func clearKeys(label: String) {
-        UserDefaults.standard.removeObject(forKey: label)
-    }
     
     /**
      Generate an elliptic curve private key for secp256k1.
      */
-    static func makeECPrivateKey() -> String? {
-
+    open static func makeECPrivateKey() -> String? {
+        
         let keyLength = 32
         let n = secp256k1Curve.n
         let nBigInt = _BigInt<UInt>(n, radix: 16)
-//        print("n")
-//        print(nBigInt?.toString() as Any)
-        
         var d: _BigInt<UInt>?
         
         repeat {
             let randomBytes = generateRandomBytes()
-//            print(randomBytes!)
             d = _BigInt<UInt>(randomBytes!, radix: 16)
-//            print("d")
-//            print(d?.toString() as Any)
         } while (d!.isNegative
             || d!.isZero
             || d?._compare(to: nBigInt!) == .equal
@@ -108,7 +41,7 @@ open class Keys {
         return d?.toString(radix: 16, lowercase: true).paddingLeft(to: keyLength * 2, with: "0")
     }
     
-    static func generateRandomBytes(bytes: Int = 32) -> String? {
+    open static func generateRandomBytes(bytes: Int = 32) -> String? {
         var randomData = Data(count: bytes)
         let count = randomData.count
         let result = randomData.withUnsafeMutableBytes {

--- a/DataTypes+ObjC.swift
+++ b/DataTypes+ObjC.swift
@@ -7,6 +7,21 @@
 
 import Foundation
 
+@objc(DecryptedValue)
+public class ObjCDecryptedValue: NSObject {
+    public let plainText: String?
+    public let bytes: Bytes?
+
+    public var isString: Bool {
+        return self.plainText != nil
+    }
+    
+    public init(_ decryptedValue: DecryptedValue) {
+        self.plainText = decryptedValue.plainText
+        self.bytes = decryptedValue.bytes
+    }
+}
+
 @objc(Profile)
 public class ObjCProfile: NSObject {
     public let type: String?

--- a/Example/Blockstack.xcodeproj/project.pbxproj
+++ b/Example/Blockstack.xcodeproj/project.pbxproj
@@ -216,12 +216,12 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = 8AGC2Z4ZX9;
+						DevelopmentTeam = AY3JH3T849;
 						LastSwiftMigration = 0900;
 					};
 					607FACE41AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = 8AGC2Z4ZX9;
+						DevelopmentTeam = AY3JH3T849;
 						LastSwiftMigration = 0900;
 						TestTargetID = 607FACCF1AFB9204008FA782;
 					};
@@ -507,7 +507,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 8AGC2Z4ZX9;
+				DEVELOPMENT_TEAM = AY3JH3T849;
 				INFOPLIST_FILE = Blockstack/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -525,7 +525,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 8AGC2Z4ZX9;
+				DEVELOPMENT_TEAM = AY3JH3T849;
 				INFOPLIST_FILE = Blockstack/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -542,7 +542,7 @@
 			baseConfigurationReference = 4F203563E3205F2FEE113060 /* Pods-Blockstack_Tests.debug.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 8AGC2Z4ZX9;
+				DEVELOPMENT_TEAM = AY3JH3T849;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
@@ -563,7 +563,7 @@
 			baseConfigurationReference = 586561B3F8D15F92646A681D /* Pods-Blockstack_Tests.release.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = 8AGC2Z4ZX9;
+				DEVELOPMENT_TEAM = AY3JH3T849;
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = Tests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;

--- a/Example/Blockstack.xcodeproj/project.pbxproj
+++ b/Example/Blockstack.xcodeproj/project.pbxproj
@@ -216,7 +216,6 @@
 				TargetAttributes = {
 					607FACCF1AFB9204008FA782 = {
 						CreatedOnToolsVersion = 6.3.1;
-						DevelopmentTeam = AY3JH3T849;
 						LastSwiftMigration = 0900;
 					};
 					607FACE41AFB9204008FA782 = {
@@ -507,7 +506,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = AY3JH3T849;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Blockstack/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
@@ -525,7 +524,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
-				DEVELOPMENT_TEAM = AY3JH3T849;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = Blockstack/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 11.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";

--- a/Example/Blockstack/ViewController.swift
+++ b/Example/Blockstack/ViewController.swift
@@ -52,13 +52,7 @@ class ViewController: UIViewController {
     }
     
     @IBAction func resetDeviceKeychain(_ sender: Any) {
-        Blockstack.shared.promptClearDeviceKeychain(redirectUri: "myBlockstackApp") { error in
-            if let error = error {
-                print("sign out failed, error: \(error)")
-            } else {
-                print("sign out success")
-            }
-        }
+        Blockstack.shared.promptClearDeviceKeychain()
     }
     
     @IBAction func putFileTapped(_ sender: Any) {

--- a/Example/Tests/EncryptionTests.swift
+++ b/Example/Tests/EncryptionTests.swift
@@ -20,7 +20,7 @@ class EncryptionSpec : QuickSpec {
             
             context("with text") {
                 let content = "all work and no play makes jack a dull boy"
-                let cipherText = Encryption.encryptECIES(recipientPublicKey: publicKey, content: content)
+                let cipherText = Blockstack.shared.encryptContent(text: content, publicKey: publicKey)
                 it("can encrypt") {
                     expect(cipherText).toNot(beNil())
                 }
@@ -29,7 +29,7 @@ class EncryptionSpec : QuickSpec {
                         fail("Invalid cipherText")
                         return
                     }
-                    guard let plainText = Encryption.decryptECIES(privateKey: privateKey, cipherObjectJSONString: cipher)?.plainText else {
+                    guard let plainText = Blockstack.shared.decryptContent(content: cipher, privateKey: privateKey)?.plainText else {
                         fail()
                         return
                     }
@@ -39,8 +39,7 @@ class EncryptionSpec : QuickSpec {
             
             context("with bytes") {
                 let data = Data(bytes: [0x01, 0x02, 0x03])
-                let cipherText = Encryption.encryptECIES(recipientPublicKey: publicKey, content: data.bytes, isString: false)
-                
+                let cipherText = Blockstack.shared.encryptContent(bytes: data.bytes, publicKey: publicKey)
                 it("can encrypt") {
                     expect(cipherText).toNot(beNil())
                 }
@@ -50,7 +49,7 @@ class EncryptionSpec : QuickSpec {
                         fail("Invalid cipherText")
                         return
                     }
-                    guard let bytes = Encryption.decryptECIES(privateKey: privateKey, cipherObjectJSONString: cipher)?.bytes else {
+                    guard let bytes = Blockstack.shared.decryptContent(content: cipher, privateKey: privateKey)?.bytes else {
                         fail()
                         return
                     }
@@ -76,7 +75,7 @@ class EncryptionSpec : QuickSpec {
                 let canDecrypt: ([String: Any]) -> Bool = { cipherObject in
                     guard let cipherData = try? JSONSerialization.data(withJSONObject: cipherObject, options: []),
                         let cipherJSON = String(data: cipherData, encoding: String.Encoding.utf8),
-                        let _ = Encryption.decryptECIES(privateKey: privateKey, cipherObjectJSONString: cipherJSON)?.plainText else {
+                        let _ = Blockstack.shared.decryptContent(content: cipherJSON, privateKey: privateKey)?.plainText else {
                             return false
                     }
                     return true
@@ -97,7 +96,7 @@ class EncryptionSpec : QuickSpec {
                 }
                 
                 it("will fail") {
-                    let decryptedContent = Encryption.decryptECIES(privateKey: privateKey, cipherObjectJSONString: corruptedCipherContent)
+                    let decryptedContent = Blockstack.shared.decryptContent(content: corruptedCipherContent, privateKey: privateKey)
                     expect(decryptedContent).to(beNil())
                 }
             }


### PR DESCRIPTION
This PR reflects some of the learnings that came from working with Afari on their iOS app.

- Key generation utilities have been cleaned up, exposed, supported in Objective-C, and documented. Specifically, `Keys.getEntropy`, `Keys.getPublicKeyFromPrivate`, `Keys.makeECPrivateKey`. Methods to store transit keys locally, retrieve them, etc. have been removed as this should be the responsibility of the consumer of the keys (the app).
- `Blockstack.encryptContent` and `Blockstack.decryptContent` have been added and supported in Objective-C, which essentially expose encryptECIES and decryptECIES. Tests have been accordingly updated.
- The `Profile` object now supports an `image` field, which contains an object of type `Content`. This allows pulling and displaying user images in apps.
- `Blockstack.promptClearDeviceKeychain` has been simplified, no longer requiring a redirectURI or completion handler.

Thank you! 