### PR TITLE
Gaia invalidation hotfix (retry putFile if config error)

### DIFF
--- a/Blockstack/Classes/Blockstack.swift
+++ b/Blockstack/Classes/Blockstack.swift
@@ -372,7 +372,21 @@ public enum BlockstackConstants {
                 completion(nil, error)
                 return
             }
-            session.putFile(to: path, content: text, encrypt: encrypt, completion: completion)
+            session.putFile(to: path, content: text, encrypt: encrypt) { url, error in
+                guard error != .configurationError else {
+                    // Retry with a new config
+                    Gaia.setLocalGaiaHubConnection() { session, error in
+                        guard let session = session, error == nil else {
+                            print("gaia connection error upon retry")
+                            completion(nil, error)
+                            return
+                        }
+                        session.putFile(to: path, content: text, encrypt: encrypt, completion: completion)
+                    }
+                    return
+                }
+                completion(url, error)
+            }
         }
     }
     
@@ -392,7 +406,21 @@ public enum BlockstackConstants {
                 completion(nil, error)
                 return
             }
-            session.putFile(to: path, content: bytes, encrypt: encrypt, completion: completion)
+            session.putFile(to: path, content: bytes, encrypt: encrypt) { url, error in
+                guard error != .configurationError else {
+                    // Retry with a new config
+                    Gaia.setLocalGaiaHubConnection() { session, error in
+                        guard let session = session, error == nil else {
+                            print("gaia connection error upon retry")
+                            completion(nil, error)
+                            return
+                        }
+                        session.putFile(to: path, content: bytes, encrypt: encrypt, completion: completion)
+                    }
+                    return
+                }
+                completion(url, error)
+            }
         }
     }
     

--- a/Blockstack/Classes/Blockstack.swift
+++ b/Blockstack/Classes/Blockstack.swift
@@ -147,6 +147,13 @@ public enum BlockstackConstants {
     }
     
     /**
+     Clear Gaia session.
+    */
+    @objc public func clearGaiaSession() {
+        Gaia.clearSession()
+    }
+    
+    /**
      Prompt web flow to clear the keychain and all settings for this device.
      WARNING: This will reset the keychain for all apps using Blockstack sign in. Apps that are already signed in will not be affected, but the user will have to reenter their 12 word seed to sign in to any new apps.
      */

--- a/Blockstack/Classes/Gaia.swift
+++ b/Blockstack/Classes/Gaia.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-public class Gaia {
+class Gaia {
 
     // TODO: Utilize promise pattern/other way of preventing simultaneous requests
     static func getOrSetLocalHubConnection(callback: @escaping (GaiaHubSession?, GaiaError?) -> Void) {

--- a/Blockstack/Classes/Gaia.swift
+++ b/Blockstack/Classes/Gaia.swift
@@ -17,17 +17,21 @@ public class Gaia {
             self.session = GaiaHubSession(with: config)
             callback(self.session, nil)
         } else {
-            let userData = ProfileHelper.retrieveProfile()
-            let hubURL = userData?.hubURL ?? BlockstackConstants.DefaultGaiaHubURL
-            guard let appPrivateKey = userData?.privateKey else {
-                // TODO: Return appropriate error
-                callback(nil, nil)
-                return
-            }
-            self.connectToHub(hubURL: hubURL, challengeSignerHex: appPrivateKey) { session, error in
-                self.session = session
-                callback(session, error)
-            }
+            self.setLocalGaiaHubConnection(callback: callback)
+        }
+    }
+    
+    static func setLocalGaiaHubConnection(callback: @escaping (GaiaHubSession?, GaiaError?) -> Void) {
+        let userData = ProfileHelper.retrieveProfile()
+        let hubURL = userData?.hubURL ?? BlockstackConstants.DefaultGaiaHubURL
+        guard let appPrivateKey = userData?.privateKey else {
+            // TODO: Return appropriate error
+            callback(nil, nil)
+            return
+        }
+        self.connectToHub(hubURL: hubURL, challengeSignerHex: appPrivateKey) { session, error in
+            self.session = session
+            callback(session, error)
         }
     }
     
@@ -54,7 +58,6 @@ public class Gaia {
                 completion(nil, GaiaError.connectionError)
                 return
             }
-            
             let bitcoinJS = BitcoinJS()
             let signature = bitcoinJS.signChallenge(privateKey: challengeSignerHex, challengeText: hubInfo!.challengeText!)
             let publicKey = Keys.getPublicKeyFromPrivate(challengeSignerHex, compressed: true)

--- a/Blockstack/Classes/Gaia.swift
+++ b/Blockstack/Classes/Gaia.swift
@@ -117,6 +117,13 @@ public struct GaiaConfig: Codable {
     public let address: String?
     public let token: String?
     public let server: String?
+    
+    public init(URLPrefix: String?, address: String?, token: String?, server: String?) {
+        self.URLPrefix = URLPrefix
+        self.address = address
+        self.token = token
+        self.server = server
+    }
 }
 
 public struct GaiaHubInfo: Codable {

--- a/Blockstack/Classes/Gaia.swift
+++ b/Blockstack/Classes/Gaia.swift
@@ -113,10 +113,10 @@ public class Gaia {
 }
 
 public struct GaiaConfig: Codable {
-    let URLPrefix: String?
-    let address: String?
-    let token: String?
-    let server: String?
+    public let URLPrefix: String?
+    public let address: String?
+    public let token: String?
+    public let server: String?
 }
 
 public struct GaiaHubInfo: Codable {

--- a/Blockstack/Classes/GaiaHubSession.swift
+++ b/Blockstack/Classes/GaiaHubSession.swift
@@ -132,6 +132,13 @@ public class GaiaHubSession {
                 completion(nil, GaiaError.requestError)
                 return
             }
+
+            // Check for specific codes that indicate config error
+            if let code = (response as? HTTPURLResponse)?.statusCode, [401, 421].contains(code) {
+                completion(nil, GaiaError.configurationError)
+                return
+            }
+            
             do {
                 let jsonDecoder = JSONDecoder()
                 let putfileResponse = try jsonDecoder.decode(PutFileResponse.self, from: data)

--- a/Blockstack/Classes/GaiaHubSession.swift
+++ b/Blockstack/Classes/GaiaHubSession.swift
@@ -135,7 +135,7 @@ public class GaiaHubSession {
             do {
                 let jsonDecoder = JSONDecoder()
                 let putfileResponse = try jsonDecoder.decode(PutFileResponse.self, from: data)
-                completion(putfileResponse.publicURL, nil)
+                completion(putfileResponse.publicURL!, nil)
             } catch {
                 completion(nil, GaiaError.invalidResponse)
             }

--- a/Blockstack/Classes/GaiaHubSession.swift
+++ b/Blockstack/Classes/GaiaHubSession.swift
@@ -134,7 +134,7 @@ public class GaiaHubSession {
             }
 
             // Check for specific codes that indicate config error
-            if let code = (response as? HTTPURLResponse)?.statusCode, [401, 421].contains(code) {
+            if let code = (response as? HTTPURLResponse)?.statusCode == 401 {
                 completion(nil, GaiaError.configurationError)
                 return
             }

--- a/Blockstack/Classes/GaiaHubSession.swift
+++ b/Blockstack/Classes/GaiaHubSession.swift
@@ -134,7 +134,7 @@ public class GaiaHubSession {
             }
 
             // Check for specific codes that indicate config error
-            if let code = (response as? HTTPURLResponse)?.statusCode == 401 {
+            if (response as? HTTPURLResponse)?.statusCode == 401 {
                 completion(nil, GaiaError.configurationError)
                 return
             }

--- a/Example/Blockstack/ViewController.swift
+++ b/Example/Blockstack/ViewController.swift
@@ -56,6 +56,9 @@ class ViewController: UIViewController {
     }
     
     @IBAction func putFileTapped(_ sender: Any) {
+//        guard self.saveInvalidGaiaConfig() else {
+//            return
+//        }
         // Put file example
         let alert = UIAlertController(title: "Put File", message: "Type a message to put in the file:", preferredStyle: .alert)
         alert.addTextField { field in
@@ -70,7 +73,7 @@ class ViewController: UIViewController {
                 if error != nil {
                     print("put file error")
                 } else {
-                    print("put file success \(publicURL!)")
+                    print("put file success \(publicURL ?? "NA")")
                 }
             }
         })
@@ -120,6 +123,30 @@ class ViewController: UIViewController {
             }
         })
         self.present(alert, animated: true)
+    }
+    
+    private func saveInvalidGaiaConfig() -> Bool {
+        // Ensure existing hub connection
+//        Blockstack.shared.putFile(to: "test", text: "hello") { _, _ in
+//        }
+
+        // Get previous gaia config
+        guard let data = UserDefaults.standard.value(forKey:
+            BlockstackConstants.GaiaHubConfigUserDefaultLabel) as? Data,
+            let config = try? PropertyListDecoder().decode(GaiaConfig.self, from: data) else {
+                return false
+        }
+        
+        // Create invalid config
+        let invalidConfig = GaiaConfig(URLPrefix: config.URLPrefix, address: config.address, token: "v1:invalidated", server: config.server)
+        
+        // Save invalid gaia config
+        Blockstack.shared.clearGaiaSession()
+        guard let encodedInvalidConfig = try? PropertyListEncoder().encode(invalidConfig) else {
+            return false
+        }
+        UserDefaults.standard.set(encodedInvalidConfig, forKey: BlockstackConstants.GaiaHubConfigUserDefaultLabel)
+        return true
     }
     
     private func updateUI() {

--- a/Example/Tests/GaiaTests.swift
+++ b/Example/Tests/GaiaTests.swift
@@ -113,6 +113,34 @@ class GaiaSpec: QuickSpec {
                     expect(result).toEventually(equal(content), timeout: 20, pollInterval: 1)
                 }
             }
+            context("with invalid config") {
+                // MARK: - Gaia__with_invalid_config__retries_upload
+                it ("retries upload") {
+                    // Get previous gaia config
+                    guard let data = UserDefaults.standard.value(forKey:
+                        BlockstackConstants.GaiaHubConfigUserDefaultLabel) as? Data,
+                        let config = try? PropertyListDecoder().decode(GaiaConfig.self, from: data) else {
+                            fail()
+                            return
+                    }
+                    
+                    // Create invalid config
+                    let invalidConfig = GaiaConfig(URLPrefix: config.URLPrefix, address: config.address, token: "v1:invalidated", server: config.server)
+                    
+                    // Save invalid gaia config
+                    Blockstack.shared.clearGaiaSession()
+                    if let encodedInvalidConfig = try? PropertyListEncoder().encode(invalidConfig) {
+                        UserDefaults.standard.set(encodedInvalidConfig, forKey: BlockstackConstants.GaiaHubConfigUserDefaultLabel)
+                    }
+                    
+                    let content = "Testing upload"
+                    var url: String?
+                    self.testUpload(fileName: fileName, content: .text(content), encrypt: false) { result in
+                        url = result
+                    }
+                    expect(url).toEventuallyNot(beNil(), timeout: 10, pollInterval: 1)
+                }
+            }
         }
     }
     


### PR DESCRIPTION
This bubbles up config errors and retries `putFile` in case of failure. This will prevent users from having to log out/log back in when we invalidate Gaia tokens.

- [x] Sample code for devs to test this in their own apps (`saveInvalidGaiaConfig` in ViewController)
- [x] Tests