### PR TITLE
Default encrypt to true in putFile method

### DIFF
--- a/Blockstack/Classes/Blockstack.swift
+++ b/Blockstack/Classes/Blockstack.swift
@@ -560,7 +560,7 @@ public enum BlockstackConstants {
      - parameter content: The retrieved content as either Bytes, String, or DecryptedContent
      - parameter error: Error returned by Gaia
      */
-    @objc public func getFile(at path: String, decrypt: Bool = false, completion: @escaping (_ content: Any?, _ error: Error?) -> Void) {
+    @objc public func getFile(at path: String, decrypt: Bool = true, completion: @escaping (_ content: Any?, _ error: Error?) -> Void) {
         Gaia.getOrSetLocalHubConnection { session, error in
             guard let session = session, error == nil else {
                 print("gaia connection error")
@@ -583,7 +583,7 @@ public enum BlockstackConstants {
      - parameter error: Error returned by Gaia
      */
     @objc public func getFile(at path: String,
-                        decrypt: Bool = false,
+                        decrypt: Bool = true,
                         username: String,
                         app: String? = nil,
                         zoneFileLookupURL: URL? = nil,

--- a/Blockstack/Classes/Blockstack.swift
+++ b/Blockstack/Classes/Blockstack.swift
@@ -493,7 +493,7 @@ public enum BlockstackConstants {
      - parameter publicURL: The publicly accessible url of the file
      - parameter error: Error returned by Gaia
      */
-    @objc public func putFile(to path: String, text: String, encrypt: Bool = false, completion: @escaping (_ publicURL: String?, _ error: Error?) -> Void) {
+    @objc public func putFile(to path: String, text: String, encrypt: Bool = true, completion: @escaping (_ publicURL: String?, _ error: Error?) -> Void) {
         Gaia.getOrSetLocalHubConnection { session, error in
             guard let session = session, error == nil else {
                 print("gaia connection error")
@@ -527,7 +527,7 @@ public enum BlockstackConstants {
      - parameter publicURL: The publicly accessible url of the file
      - parameter error: Error returned by Gaia
      */
-    @objc public func putFile(to path: String, bytes: Bytes, encrypt: Bool = false, completion: @escaping (_ publicURL: String?, _ error: Error?) -> Void) {
+    @objc public func putFile(to path: String, bytes: Bytes, encrypt: Bool = true, completion: @escaping (_ publicURL: String?, _ error: Error?) -> Void) {
         Gaia.getOrSetLocalHubConnection { session, error in
             guard let session = session, error == nil else {
                 print("gaia connection error")

--- a/Blockstack/Classes/GaiaHubSession.swift
+++ b/Blockstack/Classes/GaiaHubSession.swift
@@ -126,7 +126,7 @@ class GaiaHubSession {
         }
     }
     
-    func putFile(to path: String, content: Bytes, encrypt: Bool = false, completion: @escaping (String?, GaiaError?) -> ()) {
+    func putFile(to path: String, content: Bytes, encrypt: Bool = true, completion: @escaping (String?, GaiaError?) -> ()) {
         if encrypt {
             guard let data = self.encrypt(content: .bytes(content)) else {
                 // TODO: Error for invalid app public key?
@@ -139,7 +139,7 @@ class GaiaHubSession {
         }
     }
     
-    func putFile(to path: String, content: String, encrypt: Bool = false, completion: @escaping (String?, GaiaError?) -> ()) {
+    func putFile(to path: String, content: String, encrypt: Bool = true, completion: @escaping (String?, GaiaError?) -> ()) {
         if encrypt {
             guard let data = self.encrypt(content: .text(content)) else {
                 // TODO: Error for invalid app public key?


### PR DESCRIPTION
After talking with @yknl and @kantai, files moved to/read from Gaia are supposed to be encrypted/decrypted by default.
This would also be more consistent with the `blockstack.js` implementation.